### PR TITLE
Wrap the gecko imager twistd plugin in import protection

### DIFF
--- a/twisted/plugins/gecko2image.py
+++ b/twisted/plugins/gecko2image.py
@@ -7,20 +7,22 @@ from twisted.python import usage
 from twisted.plugin import IPlugin
 from twisted.application.service import IServiceMaker
 
-from vumidash.gecko_imager import GeckoImageServer
+# NOTE: We avoid importing vumidash.gecko_imager at the module level so
+#       that twistd can import this module even when selenium isn't available.
 
 
 class Options(usage.Options):
     optFlags = [
         ["config-help", None, "Print out help on the YAML configuration file"
                               " and exit"],
-        ]
+    ]
 
     optParameters = [
         ["config", "c", None, "The YAML configuration file"],
-        ]
+    ]
 
     def opt_config_help(self):
+        from vumidash.gecko_imager import GeckoImageServer
         print GeckoImageServer.__doc__
         print "See above for YAML configuration file parameters."
         sys.exit(0)
@@ -33,6 +35,8 @@ class Gecko2ImageServiceMaker(object):
     options = Options
 
     def makeService(self, options):
+        from vumidash.gecko_imager import GeckoImageServer
+
         config_file = options.pop("config")
         if not config_file:
             raise ValueError("please specify --config")

--- a/twisted/plugins/graphite2holodeck.py
+++ b/twisted/plugins/graphite2holodeck.py
@@ -8,20 +8,22 @@ from twisted.application.service import IServiceMaker
 
 from vumidash.graphite_client import GraphiteClient
 from vumidash.dummy_client import DummyClient
-from vumidash.holodeck_pusher import HolodeckPusherService
+
+# NOTE: We avoid importing vumidash.holodeck_pusher at the module level so
+#       that twistd can import this module even when selenium isn't available.
 
 
 class Options(usage.Options):
     optFlags = [
         ["dummy", None, "Use a dummy metrics source instead of reading"
                         " from Graphite."],
-        ]
+    ]
 
     optParameters = [
         ["graphite-url", "g", None, "The URL of the Graphite web service."],
         ["config", "c", None, "The YAML config file describing which metrics"
          " to push."],
-        ]
+    ]
 
 
 class Graphite2HolodeckServiceMaker(object):
@@ -31,6 +33,8 @@ class Graphite2HolodeckServiceMaker(object):
     options = Options
 
     def makeService(self, options):
+        from vumidash.holodeck_pusher import HolodeckPusherService
+
         graphite_url = options["graphite-url"]
         with open(options["config"]) as f:
             config = yaml.safe_load(f.read())


### PR DESCRIPTION
This is needed so that twistd doesn't complain about not being able to import the twistd plugin whenever twistd is run and selenium isn't installed.
